### PR TITLE
feat: adds testhelpers

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/vectrum-io/strongforce/pkg/db"
 	"github.com/vectrum-io/strongforce/pkg/events"
 	"github.com/vectrum-io/strongforce/pkg/forwarder"
+	"github.com/vectrum-io/strongforce/pkg/testhelper"
 	"go.uber.org/zap"
 )
 
@@ -58,4 +59,11 @@ func (sf *Client) Bus() bus.Bus {
 
 func (sf *Client) EventBuilder() *events.Builder {
 	return sf.eventBuilder
+}
+
+func (sf *Client) TestHelper() *testhelper.TestHelper {
+	return &testhelper.TestHelper{
+		DB:  sf.db,
+		Bus: sf.bus,
+	}
 }

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -13,6 +13,12 @@ type Bus interface {
 	Subscribe(ctx context.Context, subscriberName string, stream string, opts ...SubscribeOption) (*Subscription, error)
 	// Migrate ensures that dependencies (streams, topic, consumers, etc.) are up to date and ready to be used
 	Migrate(ctx context.Context) error
+	// SubscriberInfo retrieves information about a subscriber in a stream
+	SubscriberInfo(ctx context.Context, stream string, subscriberName string) (SubscriberInfo, error)
+}
+
+type SubscriberInfo interface {
+	HasPendingMessages() bool
 }
 
 type OutboundMessage struct {

--- a/pkg/bus/nats/bus.go
+++ b/pkg/bus/nats/bus.go
@@ -26,7 +26,6 @@ type Options struct {
 }
 
 func New(options *Options) (*Bus, error) {
-
 	if options.Logger == nil {
 		options.Logger = zap.L()
 	}
@@ -136,4 +135,20 @@ func (b *Bus) Migrate(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (b *Bus) SubscriberInfo(ctx context.Context, stream string, consumerName string) (bus.SubscriberInfo, error) {
+	consumer, err := b.subscriber.jetStream.Consumer(ctx, stream, consumerName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get consumer: %w", err)
+	}
+
+	consumerInfo, err := consumer.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get consumer info: %w", err)
+	}
+
+	return &SubscriberInfo{
+		jsConsumerInfo: consumerInfo,
+	}, nil
 }

--- a/pkg/bus/nats/subscriber_info.go
+++ b/pkg/bus/nats/subscriber_info.go
@@ -1,0 +1,11 @@
+package nats
+
+import "github.com/nats-io/nats.go/jetstream"
+
+type SubscriberInfo struct {
+	jsConsumerInfo *jetstream.ConsumerInfo
+}
+
+func (si *SubscriberInfo) HasPendingMessages() bool {
+	return si.jsConsumerInfo.NumPending > 0 || si.jsConsumerInfo.NumAckPending > 0
+}

--- a/pkg/testhelper/helper.go
+++ b/pkg/testhelper/helper.go
@@ -1,0 +1,23 @@
+package testhelper
+
+import (
+	"fmt"
+	"github.com/vectrum-io/strongforce/pkg/bus"
+	"github.com/vectrum-io/strongforce/pkg/db"
+)
+
+type TestHelper struct {
+	DB  db.DB
+	Bus bus.Bus
+}
+
+func (th *TestHelper) Outbox() (*OutboxHelpers, error) {
+	if th.Bus == nil || th.DB == nil {
+		return nil, fmt.Errorf("bus and db must be set to use outbox test helpers")
+	}
+
+	return &OutboxHelpers{
+		bus: th.Bus,
+		db:  th.DB,
+	}, nil
+}

--- a/pkg/testhelper/outbox.go
+++ b/pkg/testhelper/outbox.go
@@ -1,0 +1,81 @@
+package testhelper
+
+import (
+	"context"
+	"fmt"
+	"github.com/vectrum-io/strongforce/pkg/bus"
+	"github.com/vectrum-io/strongforce/pkg/db"
+	"time"
+)
+
+type OutboxHelpers struct {
+	bus bus.Bus
+	db  db.DB
+}
+
+func (oh *OutboxHelpers) WaitUntilEventProcessed(ctx context.Context, timeout time.Duration, interval time.Duration, outboxTableName string, streamName string, consumerName string) error {
+	if err := oh.WaitUntilOutboxEmpty(ctx, timeout, interval, outboxTableName); err != nil {
+		return fmt.Errorf("failed to wait until outbox is empty: %w", err)
+	}
+
+	if err := oh.WaitUntilBusEmpty(ctx, timeout, interval, streamName, consumerName); err != nil {
+		return fmt.Errorf("failed to wait until bus is empty: %w", err)
+	}
+
+	return nil
+}
+
+func (oh *OutboxHelpers) WaitUntilOutboxEmpty(ctx context.Context, timeout time.Duration, interval time.Duration, outboxTableName string) error {
+	// Create a context with timeout to enforce the maximum wait duration
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	sql := oh.db.Connection().Rebind("SELECT COUNT(*) FROM " + outboxTableName)
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			// Timeout or cancellation reached
+			return fmt.Errorf("timed out waiting for the outbox to be empty: %w", timeoutCtx.Err())
+		case <-ticker.C:
+			var count int
+			if err := oh.db.Connection().GetContext(ctx, &count, sql); err != nil {
+				return fmt.Errorf("failed to get outbox count: %w", err)
+			}
+
+			if count == 0 {
+				// Outbox is empty, return nil
+				return nil
+			}
+		}
+	}
+}
+
+func (oh *OutboxHelpers) WaitUntilBusEmpty(ctx context.Context, timeout time.Duration, interval time.Duration, streamName string, consumerName string) error {
+	// Create a context with timeout to enforce the maximum wait duration
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			// Timeout or cancellation reached
+			return fmt.Errorf("timed out waiting for the bus to be empty: %w", timeoutCtx.Err())
+		case <-ticker.C:
+			subscriberInfo, err := oh.bus.SubscriberInfo(ctx, streamName, consumerName)
+			if err != nil {
+				return fmt.Errorf("failed to get subscriber info: %w", err)
+			}
+
+			if !subscriberInfo.HasPendingMessages() {
+				return nil
+			}
+		}
+	}
+}

--- a/tests/mocks/bus.go
+++ b/tests/mocks/bus.go
@@ -29,3 +29,8 @@ func (b *Bus) Migrate(ctx context.Context) error {
 	args := b.Called()
 	return args.Error(0)
 }
+
+func (b *Bus) SubscriberInfo(ctx context.Context, stream string, consumerName string) (bus.SubscriberInfo, error) {
+	args := b.Called(stream, consumerName)
+	return args.Get(0).(bus.SubscriberInfo), args.Error(1)
+}


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `client.go`, `pkg/bus`, and `pkg/testhelper` modules. The key changes include adding a new `TestHelper` utility, extending the `Bus` interface, and implementing methods to facilitate testing and subscriber information retrieval.

### Enhancements and New Features

* `client.go`:
  * Added import for `testhelper` package.
  * Introduced `TestHelper` method to the `Client` struct to provide easy access to testing utilities.

* `pkg/bus`:
  * Extended the `Bus` interface to include the `SubscriberInfo` method and added the `SubscriberInfo` interface.
  * Implemented the `SubscriberInfo` method in the `Bus` struct to retrieve consumer information from JetStream.
  * Created the `SubscriberInfo` struct in `pkg/bus/nats/subscriber_info.go` to encapsulate consumer information and provide a method to check for pending messages.

* `pkg/testhelper`:
  * Added `TestHelper` struct to simplify testing by bundling `DB` and `Bus` dependencies.
  * Introduced `OutboxHelpers` struct with methods to wait until the outbox and bus are empty, aiding in testing event processing.

### Testing Enhancements

* `tests/mocks/bus.go`:
  * Added mock implementation of the `SubscriberInfo` method to the `Bus` mock for unit testing.